### PR TITLE
avoid absolute paths in mp3_path

### DIFF
--- a/index.py
+++ b/index.py
@@ -48,7 +48,7 @@ def index_songs():
             if file.endswith('.mp3'):
                 batch -= 1
                 # get relative path for api route later
-                mp3_path = os.path.join(root, file).replace(SONGFOLDER, '')
+                mp3_path = os.path.join(root, file).replace(SONGFOLDER, '').strip("/")
                 # get metadata
                 # search for txt in same folder
                 # the name of the txt file is NOT the same as the mp3 file, so replacing the extension is not enough


### PR DESCRIPTION
On a linux system the path delimiters are `/`. Currently this results in mp3_paths with a leading `/`.
However, this makes the `os.path.join` function keep only the mp3_path argument and ignoring the `SONGFOLDER` argument leading to file not found errors.
This can easily be mitigated by applying a `.strip("/")` when creating the mp3_path.